### PR TITLE
Replace adjustPyClass with adjustInterfaceIR

### DIFF
--- a/type-generation/extract.ts
+++ b/type-generation/extract.ts
@@ -315,7 +315,8 @@ export function renderTypeIR(
 }
 
 function renderTypeIRInner(ir: TypeIR, settings: RenderTypeSettings): string {
-  const { variance, numberType } = settings;
+  const { variance, numberType, topLevelName } = settings;
+  settings.topLevelName = undefined;
   if (ir.kind === "simple") {
     return ir.text;
   }
@@ -345,7 +346,11 @@ function renderTypeIRInner(ir: TypeIR, settings: RenderTypeSettings): string {
     return renderTypeIR(ir.type, settings);
   }
   if (ir.kind === "callable") {
-    return renderIRSignatures(ir.signatures, settings);
+    return renderIRSignatures(ir.signatures, {
+      variance,
+      topLevelName,
+      numberType,
+    });
   }
   if (ir.kind === "other") {
     return "Any";

--- a/type-generation/render.ts
+++ b/type-generation/render.ts
@@ -2,7 +2,6 @@ import {
   CLASS_TYPE_IGNORES,
   METHOD_TYPE_IGNORES,
   PROPERTY_TYPE_IGNORES,
-  adjustPyClass,
   adjustPySig,
 } from "./adjustments.ts";
 import { PyClass } from "./types.ts";
@@ -10,7 +9,7 @@ import { PyClass } from "./types.ts";
 export type PyParam = {
   name: string;
   pyType: string;
-  optional: boolean;
+  isOptional: boolean;
 };
 export type PySig = {
   params: PyParam[];
@@ -39,7 +38,6 @@ function indent(x: string, prefix: string): string {
 }
 
 export function renderPyClass(cls: PyClass): string {
-  adjustPyClass(cls);
   let { name, supers, body } = cls;
   if (body.trim() === "") {
     body = "pass";
@@ -126,7 +124,7 @@ export function sanitizeReservedWords(name) {
   return name;
 }
 
-function renderParam({ name, pyType, optional }: PyParam) {
+function renderParam({ name, pyType, isOptional: optional }: PyParam) {
   const maybeDefault = optional ? " = None" : "";
   name = sanitizeReservedWords(name);
   return `${name}: ${pyType}${maybeDefault}`;

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -53,7 +53,7 @@ function convertType(
   topLevelName?: string,
 ): string {
   const ir = typeToIR(typeNode);
-  return renderTypeIR(ir, isOptional, variance, topLevelName);
+  return renderTypeIR(ir, { isOptional, variance, topLevelName });
 }
 
 function convertPropertySignature(
@@ -78,7 +78,7 @@ function convertBuiltinVariable(varName: string): string[] {
   project.createSourceFile("/a.ts", varName);
   const x = project.getSourceFileOrThrow("/a.ts");
   const id = x.getStatements()[0].getChildren()[0] as Identifier;
-  console.log(id.getDefinitionNodes().map(x => x.getKindName()));
+  console.log(id.getDefinitionNodes().map((x) => x.getKindName()));
   // process.exit(1);
   const varDecl = id.getDefinitionNodes().filter(Node.isVariableDeclaration)[0];
   const ir = convertDecls([varDecl], []);
@@ -742,10 +742,5 @@ describe("emit", () => {
         "def clearTimeout(id: int | JsProxy, /) -> None: ...",
       );
     });
-    // it.only("Response", () => {
-    //   const res = convertBuiltinVariable("Response");
-    //   process.exit(1);
-    //   console.log(res.join("\n\n"));
-    // });
-  })
+  });
 });

--- a/type-generation/tests/ir.test.ts
+++ b/type-generation/tests/ir.test.ts
@@ -16,11 +16,7 @@ describe("typeToIR", () => {
     it("convert number", () => {
       const typeIR = typeToIRHelper("number");
       expect(typeIR).toEqual({
-        kind: "union",
-        types: [
-          { kind: "simple", text: "int" },
-          { kind: "simple", text: "float" },
-        ],
+        kind: "number",
       });
     });
     it("convert union", () => {
@@ -130,7 +126,7 @@ describe("typeToIR", () => {
               {
                 name: "a",
                 type: { kind: "simple", text: "str" },
-                optional: true,
+                isOptional: true,
               },
             ],
             spreadParam: undefined,
@@ -155,7 +151,7 @@ describe("typeToIR", () => {
                     { kind: "simple", text: "None" },
                   ],
                 },
-                optional: true,
+                isOptional: true,
               },
             ],
             spreadParam: undefined,
@@ -174,7 +170,7 @@ describe("typeToIR", () => {
               {
                 name: "a",
                 type: { kind: "simple", text: "Any" },
-                optional: false,
+                isOptional: false,
               },
             ],
             spreadParam: undefined,
@@ -193,7 +189,7 @@ describe("typeToIR", () => {
             spreadParam: {
               name: "a",
               type: { kind: "array", type: { kind: "simple", text: "str" } },
-              optional: false,
+              isOptional: false,
             },
             returns: { kind: "simple", text: "None" },
           },


### PR DESCRIPTION
For adding the extra signature to the json method, this is easier since we can operate on a richer data structure than a text blob.

For deciding the format of the numbers, we can't use replaceAll anymore. Instead I added a separate type to the IR to indicate that we have the conversion of number, and added an extra setting to the type conversion to indicate how number should be rendered. By default it is `int | float`, but we can modify it to `int`.

Since the number of settings for the type to IR converter was getting out of hand, I added a settings object for it. Probably we should add these for the other conversion functions too...