### PR TITLE
Refactor handling toplevels

### DIFF
--- a/type-generation/extract.ts
+++ b/type-generation/extract.ts
@@ -16,7 +16,6 @@ import {
   callableIRToString,
   declarationIRToString,
   interfaceIRToString,
-  topLevelIRToString,
   typeAliasIRToString,
 } from "./irToString.ts";
 

--- a/type-generation/extract.ts
+++ b/type-generation/extract.ts
@@ -6,8 +6,19 @@ import {
   getExtraBases,
 } from "./adjustments.ts";
 
-import { InterfaceIR, convertFiles, ConversionResult } from "./astToIR.ts";
-import { topLevelIRToString } from "./irToString.ts";
+import {
+  InterfaceIR,
+  convertFiles,
+  ConversionResult,
+  TopLevels,
+} from "./astToIR.ts";
+import {
+  callableIRToString,
+  declarationIRToString,
+  interfaceIRToString,
+  topLevelIRToString,
+  typeAliasIRToString,
+} from "./irToString.ts";
 
 function topologicalSortClasses(
   nameToCls: Map<string, InterfaceIR>,
@@ -71,28 +82,38 @@ export function emitFiles(files: SourceFile[]): string[] {
   return emitIR(result);
 }
 
-export function emitIR({ topLevels, typeParams }: ConversionResult): string[] {
-  const classes = topLevels.filter(
-    (x): x is InterfaceIR => x.kind === "interface",
-  );
+function adjustIR(topLevels: TopLevels): void {
+  const classes = topLevels.ifaces;
   const nameToCls = new Map(classes.map((cls) => [cls.name, cls]));
   if (nameToCls.size < classes.length) {
     throw new Error("Duplicate");
   }
   fixupClassBases(nameToCls);
   classes.forEach(adjustInterfaceIR);
-  for (let obj of topLevels) {
-    if (obj.kind === "callable") {
-      adjustFunction(obj);
-    }
-    if (obj.kind === "interface") {
-      obj.methods.forEach(adjustFunction);
-    }
+  topLevels.callables.forEach(adjustFunction);
+  for (const iface of topLevels.ifaces) {
+    iface.methods.forEach(adjustFunction);
   }
-  const typevarDecls = Array.from(
+}
+
+export function emitIR({ topLevels, typeParams }: ConversionResult): string[] {
+  adjustIR(topLevels);
+  const typevarStrings = Array.from(
     typeParams,
     (x) => `${x} = TypeVar("${x}")`,
   ).join("\n");
-  const rendered = topLevels.map((e) => topLevelIRToString(e));
-  return [PRELUDE, typevarDecls, ...rendered];
+  const typeAliasStrings = topLevels.typeAliases.map(typeAliasIRToString);
+  const declarationStrings = topLevels.decls.map(declarationIRToString);
+  const callableStrings = topLevels.callables.flatMap((tl) =>
+    callableIRToString(tl, false),
+  );
+  const interfaceStrings = topLevels.ifaces.flatMap(interfaceIRToString);
+  return [
+    PRELUDE,
+    typevarStrings,
+    ...typeAliasStrings,
+    ...declarationStrings,
+    ...callableStrings,
+    ...interfaceStrings,
+  ];
 }

--- a/type-generation/irToString.ts
+++ b/type-generation/irToString.ts
@@ -7,11 +7,13 @@ import {
 import {
   BaseIR,
   CallableIR,
+  DeclarationIR,
   InterfaceIR,
   ParamIR,
   PropertyIR,
   SigIR,
   TopLevelIR,
+  TypeAliasIR,
   TypeIR,
 } from "./astToIR.ts";
 import { assertUnreachable } from "./astUtils.ts";
@@ -175,27 +177,17 @@ function simpleDeclaration(name: string, type: string) {
 // Functions that format IR into strings
 //
 
-export function topLevelIRToString(toplevel: TopLevelIR): string {
-  if (toplevel.kind === "declaration") {
-    const { name, type } = toplevel;
-    const typeStr = typeIRToString(type);
-    return simpleDeclaration(name, typeStr);
-  }
-  if (toplevel.kind === "typeAlias") {
-    const { name, type } = toplevel;
-    const typeStr = typeIRToString(type);
-    return `${name} = ${typeStr}`;
-  }
-  if (toplevel.kind === "interface") {
-    return interfaceIRToString(toplevel);
-  }
-  if (toplevel.kind === "callable") {
-    return callableIRToString(toplevel, false).join("\n");
-  }
-  assertUnreachable(toplevel);
+export function declarationIRToString({ name, type }: DeclarationIR): string {
+  const typeStr = typeIRToString(type);
+  return simpleDeclaration(name, typeStr);
 }
 
-function interfaceIRToString({
+export function typeAliasIRToString({ name, type }: TypeAliasIR): string {
+  const typeStr = typeIRToString(type);
+  return `${name} = ${typeStr}`;
+}
+
+export function interfaceIRToString({
   name,
   properties,
   methods,

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -295,7 +295,7 @@ describe("property signature", () => {
 function convertVarDecl(astVarDecl: VariableDeclaration): string {
   const astConverter = new AstConverter();
   const irVarDecl = astConverter.varDeclToIR(astVarDecl);
-  switch(irVarDecl.kind) {
+  switch (irVarDecl.kind) {
     case "callable":
       return callableIRToString(irVarDecl, false).join("\n");
     case "declaration":

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -14,8 +14,10 @@ import {
   propertyIRToString,
   baseIRToString,
   callableIRToString,
-  topLevelIRToString,
   typeIRToString,
+  declarationIRToString,
+  interfaceIRToString,
+  typeAliasIRToString,
 } from "../irToString.ts";
 import { Variance } from "../types.ts";
 import {
@@ -293,7 +295,16 @@ describe("property signature", () => {
 function convertVarDecl(astVarDecl: VariableDeclaration): string {
   const astConverter = new AstConverter();
   const irVarDecl = astConverter.varDeclToIR(astVarDecl);
-  return topLevelIRToString(irVarDecl);
+  switch(irVarDecl.kind) {
+    case "callable":
+      return callableIRToString(irVarDecl, false).join("\n");
+    case "declaration":
+      return declarationIRToString(irVarDecl);
+    case "interface":
+      return interfaceIRToString(irVarDecl);
+    case "typeAlias":
+      return typeAliasIRToString(irVarDecl);
+  }
 }
 
 function convertFuncDeclGroup(
@@ -767,7 +778,7 @@ describe("emit", () => {
   describe("adjustments", () => {
     it("setTimeout", () => {
       const res = emitIRNoTypeIgnores(convertBuiltinFunction("setTimeout"));
-      expect(res.at(-2)).toBe(
+      expect(res.at(-1)).toBe(
         "def setTimeout(handler: TimerHandler, timeout: int | float | None = None, /, *arguments: Any) -> int | JsProxy: ...",
       );
     });


### PR DESCRIPTION
Group toplevels by type from the beginning. Move adjustments into a separate function.