### PR TITLE
Refactor type parameter in preparation for variance calculation

### DIFF
--- a/type-generation/astToIR.ts
+++ b/type-generation/astToIR.ts
@@ -62,13 +62,13 @@ export type OtherTypeIR = { kind: "other"; nodeKind: string; location: string };
 
 export type ClassParameterReferenceIR = {
   kind: "parameterReference";
-  type: "function";
-  name: string;
+  type: "class";
+  idx: number;
 };
 export type FunctionParameterReferenceIR = {
   kind: "parameterReference";
-  type: "class";
-  idx: number;
+  type: "function";
+  name: string;
 };
 export type ParameterReferenceTypeIR =
   | ClassParameterReferenceIR
@@ -264,7 +264,6 @@ export class Converter {
   funcTypeParams: Set<string>;
   neededSet: Set<Needed>;
   convertedSet: Set<string>;
-  classTypeParams: string[];
 
   constructor() {
     this.funcTypeParams = new Set();

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -102,21 +102,21 @@ function convertBuiltinVariable(varName: string): ConversionResult {
 function emitBuiltinVariable(varName: string): string[] {
   return emitIRNoTypeIgnores(convertBuiltinVariable(varName));
 }
-function convertBuiltinIface(varName: string): ConversionResult {
-  const project = makeProject();
-  project.createSourceFile("/a.ts", `let _added: ${varName};`);
-  const x = project.getSourceFileOrThrow("/a.ts");
-  const ref = x
-    .getFirstDescendantByKindOrThrow(SyntaxKind.VariableDeclaration)
-    .getTypeNode()
-    .asKindOrThrow(SyntaxKind.TypeReference);
-  const id = ref.getTypeName() as Identifier;
-  const converter = new Converter();
-  return {
-    topLevels: [converter.identToIR(id)],
-    typeParams: converter.funcTypeParams,
-  };
-}
+// function convertBuiltinIface(varName: string): ConversionResult {
+//   const project = makeProject();
+//   project.createSourceFile("/a.ts", `let _added: ${varName};`);
+//   const x = project.getSourceFileOrThrow("/a.ts");
+//   const ref = x
+//     .getFirstDescendantByKindOrThrow(SyntaxKind.VariableDeclaration)
+//     .getTypeNode()
+//     .asKindOrThrow(SyntaxKind.TypeReference);
+//   const id = ref.getTypeName() as Identifier;
+//   const converter = new Converter();
+//   return {
+//     topLevels: [converter.identToIR(id)],
+//     typeParams: converter.funcTypeParams,
+//   };
+// }
 
 describe("typeToPython", () => {
   it("convert string", () => {
@@ -323,7 +323,7 @@ function convertVarDecl(astVarDecl: VariableDeclaration): string {
   const irVarDecl = astConverter.varDeclToIR(astVarDecl);
   switch (irVarDecl.kind) {
     case "callable":
-      return callableIRToString(irVarDecl, false).join("\n");
+      return callableIRToString(irVarDecl, {isMethod: false}).join("\n");
     case "declaration":
       return declarationIRToString(irVarDecl);
     case "interface":

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -291,7 +291,7 @@ describe("property signature", () => {
       }
       declare var Test: X[];
     `);
-    expect(removeTypeIgnores(res.slice(2).join("\n\n"))).toBe(
+    expect(removeTypeIgnores(res.slice(1).join("\n\n"))).toBe(
       dedent(`\
         Test: JsArray[X_iface] = ...
 
@@ -307,7 +307,7 @@ describe("property signature", () => {
       }
       declare var Test: X[];
     `);
-    expect(removeTypeIgnores(res.slice(2).join("\n\n"))).toBe(
+    expect(removeTypeIgnores(res.slice(1).join("\n\n"))).toBe(
       dedent(`\
         Test: JsArray[X_iface] = ...
 

--- a/type-generation/tests/helpers.ts
+++ b/type-generation/tests/helpers.ts
@@ -3,7 +3,7 @@ import { Converter as AstConverter } from "../astToIR";
 import { TypeNode } from "ts-morph";
 
 export function typeToIR(t: TypeNode) {
-  return new AstConverter().typeToIR(t);
+  return new AstConverter().typeToIR(t, false, []);
 }
 
 export function makeProject(): Project {

--- a/type-generation/types.ts
+++ b/type-generation/types.ts
@@ -61,10 +61,12 @@ export type Needed =
   | { type: "interface"; ident: Identifier };
 
 export enum Variance {
+  invar = 0,
   covar = 1,
   contra = -1,
-  none = 0,
+  bivar = NaN,
 }
+
 export function reverseVariance(v: Variance): Variance {
   return -v;
 }


### PR DESCRIPTION
Only class type parameters have variance so the IR gains a new distinction between a `ClassParameterReference` and a `FunctionParameterReference`. The `FunctionParameterReference` in the IR just has a name, but the `ClassParameterReference` instead carries an index into the list of class parameters which is specific to the context of the class that we are inside. This lets us calculate the variance of the class type parameters as an intermediate step (TODO) so that the variance information will be available when rendering.

So when we first start processing a class, we ask what set of type parameters there are. We do this by looking at the return type of the class constructor which should give us the name and ordering of the parameters.
Then we have to pass this list of class parameter names around when generating the IR. When converting from IR to a string, we start by converting all of the type parameters to their string representations (including a "co"/"contra" suffix if needed) so that if we render a  `ClassParameterReference` we can figure out what the corresponding identifier is.

Instead of putting the class type parameters in the `converter.typeParams` list, we keep them separate since we need to distinguish between `T`, `Tco`, and `Tcontra`. When we are generating the list of TypeVar decls we iterate over all the classes and generate their type variable names using the variance which we have chosen at this point. Then we unique-by name and generate the output list of typevars. This can be simplified once we switch to using Python 3.12 type parameter syntax.