### PR TITLE
Emit an interface for a type alias to type literal

### DIFF
--- a/type-generation/src/astToIR.ts
+++ b/type-generation/src/astToIR.ts
@@ -1379,10 +1379,24 @@ export class Converter {
         throw new Error("Unhandled");
       case "typeAlias":
         this.nameContext = [name];
-        const type = this.typeToIR(classified.decl.getTypeNode()!);
         const aliasTypeParams = classified.decl
           .getTypeParameters()
           .map((p) => p.getName());
+        const typeNode = classified.decl.getTypeNode()!;
+        // If the typeNode is a type literal, emit an interface instead of a
+        // type alias. This reduces redundancy. Also, interfaces can be used in
+        // bases.
+        if (Node.isTypeLiteral(typeNode)) {
+          return this.interfaceToIR(
+            name,
+            [],
+            typeNode.getMembers(),
+            [],
+            [],
+            aliasTypeParams,
+          );
+        }
+        const type = this.typeToIR(typeNode);
         this.nameContext = undefined;
         return { kind: "typeAlias", name, type, typeParams: aliasTypeParams };
       case "varDecl":

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -1395,11 +1395,9 @@ describe("emit", () => {
       assert.strictEqual(
         removeTypeIgnores(res.slice(1).join("\n\n")),
         dedent(`
-          type A = A_iface
-
           def f() -> A: ...
 
-          class A_iface(Protocol):
+          class A(Protocol):
               a: Literal[1, 2, 3, 4, 5] | None = ...
               b: int | float | None = ...
               c: Literal['a', 'b', 'c'] | None = ...
@@ -1434,16 +1432,15 @@ describe("emit", () => {
       assert.strictEqual(
         removeTypeIgnores(res.slice(1).join("\n\n")),
         dedent(`
-          type A = A_iface
-
           def f() -> A: ...
+
+          class A(Protocol):
+              a: int | float = ...
+              b: A__b_iface = ...
 
           class A__b_iface(Protocol):
               c: int | float = ...
 
-          class A_iface(Protocol):
-              a: int | float = ...
-              b: A__b_iface = ...
         `).trim(),
       );
     });
@@ -1640,13 +1637,11 @@ describe("emit", () => {
         assert.strictEqual(
           removeTypeIgnores(res.slice(1).join("\n\n")),
           dedent(`
-            type A = A_iface
-
             type B = A
 
             def f(a: A, b: B, /) -> None: ...
 
-            class A_iface(Protocol):
+            class A(Protocol):
                 s: bool | None = ...
                 t: str | None = ...
           `).trim(),


### PR DESCRIPTION
This reduces redundancy. Also, interfaces can be used in bases.